### PR TITLE
add to the table view extension `reusableHeaderFooterView` method group

### DIFF
--- a/Source/UITableView+Swissors.swift
+++ b/Source/UITableView+Swissors.swift
@@ -22,4 +22,18 @@ public extension UITableView {
     public func dequeueReusableCellOfType<T: UITableViewCell>(_ cellType: T.Type, forIndexPath indexPath: IndexPath) -> T {
         return dequeueReusableCell(withIdentifier: String(describing: cellType), for: indexPath) as! T
     }
+    
+    public func registerReusableHeaderFooterViewOfType<T: UITableViewHeaderFooterView>(_ viewType: T.Type) {
+        register(viewType, forHeaderFooterViewReuseIdentifier: String(describing: viewType))
+    }
+    
+    public func registerHeaderFooterViewNibOfType<T: UITableViewHeaderFooterView>(_ viewType: T.Type, bundle: Bundle?) {
+        let nib = UINib(nibName: String(describing: viewType), bundle: bundle)
+        register(nib, forHeaderFooterViewReuseIdentifier: String(describing: viewType))
+    }
+    
+    public func dequeueReusableHeaderFooterViewOfType<T: UITableViewHeaderFooterView>(_ viewType: T.Type, forIndexPath indexPath: IndexPath) -> T {
+        let identifier = String(describing: viewType)
+        return (dequeueReusableHeaderFooterView(withIdentifier: identifier) ?? T(reuseIdentifier: identifier)) as! T
+    }
 }

--- a/Swissors.podspec
+++ b/Swissors.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = 'Swissors'
-  s.version                 = '1.2.0'
+  s.version                 = '1.2.1'
   s.summary                 = 'Swift utilities'
   s.homepage                = 'https://github.com/elegion/ios-Swissors'
   s.license                 = 'MIT'


### PR DESCRIPTION
Добавлены методы для регистрации и переиспользования футеров и хедеров
